### PR TITLE
MIDI control of NeuralPi parameters

### DIFF
--- a/elk_configs/config_neuralpi_MIDI.json
+++ b/elk_configs/config_neuralpi_MIDI.json
@@ -1,0 +1,148 @@
+{
+    "host_config" : {
+        "samplerate" : 44100
+    },
+    "tracks" : [
+        {
+            "name" : "main",
+            "mode" : "stereo",
+            "inputs" : [
+                {
+                    "engine_bus" : 0,
+                    "track_bus" : 0
+                }
+            ],
+            "outputs" : [
+                {
+                    "engine_bus" : 0,
+                    "track_bus" : 0
+                }
+            ],
+            "plugins" : [
+			    {
+				    "uid"  : "sushi.testing.mono_summing",
+					"name" : "mono_summing",
+					"type" : "internal"
+				},
+                {
+                    "uid"  : "NeuralPi",
+                    "path" : "/home/mind/plugins/NeuralPi.vst3",
+                    "name" : "NeuralPi",
+                    "type" : "vst3x"
+                }
+            ]
+        }
+    ],
+    "midi" : {
+	"track_connections": [
+            {
+                "port": 0,
+                "channel": "all",
+                "track": "main",
+                "raw_midi": false
+            }
+        ],
+	"cc_mappings": [
+	    {
+                "port": 0,
+                "channel": "all",
+                "plugin_name": "NeuralPi",
+                "cc_number": 1,
+		"parameter_name": "Gain",
+		"min_range": 0.0,
+		"max_range": 1.0,
+		"mode": "absolute"
+            },
+ 	    {
+                "port": 0,
+                "channel": "all",
+                "plugin_name": "NeuralPi",
+                "cc_number": 2,
+		"parameter_name": "Master",
+		"min_range": 0.0,
+		"max_range": 1.0,
+		"mode": "absolute"
+            },
+ 	    {
+                "port": 0,
+                "channel": "all",
+                "plugin_name": "NeuralPi",
+                "cc_number": 3,
+		"parameter_name": "Bass",
+		"min_range": 0.0,
+		"max_range": 1.0,
+		"mode": "absolute"
+            },
+	    {
+                "port": 0,
+                "channel": "all",
+                "plugin_name": "NeuralPi",
+                "cc_number": 4,
+		"parameter_name": "Mid",
+		"min_range": 0.0,
+		"max_range": 1.0,
+		"mode": "absolute"
+            },
+	    {
+                "port": 0,
+                "channel": "all",
+                "plugin_name": "NeuralPi",
+                "cc_number": 5,
+		"parameter_name": "Treble",
+		"min_range": 0.0,
+		"max_range": 1.0,
+		"mode": "absolute"
+            },
+ 	    {
+                "port": 0,
+                "channel": "all",
+                "plugin_name": "NeuralPi",
+                "cc_number": 6,
+		"parameter_name": "Presence",
+		"min_range": 0.0,
+		"max_range": 1.0,
+		"mode": "absolute"
+            },
+ 	    {
+                "port": 0,
+                "channel": "all",
+                "plugin_name": "NeuralPi",
+                "cc_number": 7,
+		"parameter_name": "Delay",
+		"min_range": 0.0,
+		"max_range": 1.0,
+		"mode": "absolute"
+            },
+ 	    {
+                "port": 0,
+                "channel": "all",
+                "plugin_name": "NeuralPi",
+                "cc_number": 8,
+		"parameter_name": "Reverb",
+		"min_range": 0.0,
+		"max_range": 1.0,
+		"mode": "absolute"
+            },
+ 	    {
+                "port": 0,
+                "channel": "all",
+                "plugin_name": "NeuralPi",
+                "cc_number": 9,
+		"parameter_name": "Model",
+		"min_range": 0.0,
+		"max_range": 1.0,
+		"mode": "absolute"
+            },
+	    {
+                "port": 0,
+                "channel": "all",
+                "plugin_name": "NeuralPi",
+                "cc_number": 10,
+		"parameter_name": "Ir",
+		"min_range": 0.0,
+		"max_range": 1.0,
+		"mode": "absolute"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Added a new config file, "config_neuralpi_MIDI.json", which now includes MIDI CC# mappings of NeuralPi parameters.

Also, REAMDE file has been modified in order to include the explanation of MIDI mapping.